### PR TITLE
feat: center items for mobile section about

### DIFF
--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -51,7 +51,7 @@ export const About: React.FC = () => {
                     <Image className='rounded-xl' aria-label='Related Image' width={423} height={600} src='https://picsum.photos/id/59/282/408' alt="Image about me" />
                 </motion.div>
                 <motion.div variants={item} className="col-start-2 row-start-3 row-end-5">
-                    <Image className='rounded-xl' aria-label='Related Image'  width={423} height={600} src='https://picsum.photos/id/69/282/408' alt="Image about me" />
+                    <Image className='rounded-xl' aria-label='Related Image' width={423} height={600} src='https://picsum.photos/id/69/282/408' alt="Image about me" />
                 </motion.div>
             </motion.div>
         </section>

--- a/components/sections/About.tsx
+++ b/components/sections/About.tsx
@@ -20,7 +20,7 @@ const item = {
 
 export const About: React.FC = () => {
   return (
-        <section id="about" className="flex items-center py-24">
+        <section id="about" className="flex flex-col md:flex-row items-center py-12 md:py-24">
             <motion.article
                 initial= {{ x: -100, opacity: 0 }}
                 whileInView={{ x: 0, opacity: 1 }}
@@ -28,7 +28,7 @@ export const About: React.FC = () => {
                   amount: 0.7,
                   once: true
                 }}
-                className="mr-0 text-center sm:mr-8 sm:w-1/2 sm:text-left">
+                className="mr-0 text-center sm:mr-8 md:w-1/2 md:text-left">
                 <h4 className="uppercase text-h4 mb-2 sm:mb-0">A bit about me</h4>
                 <h3 className="text-neutral-2 text-h3 font-light leading-normal">
                     I am a UI/UX designer who is passionate about creating <b className="text-neutral-1">beautiful and joyful digital experiences. Besides design, I love music, games and travelling.</b>
@@ -42,16 +42,16 @@ export const About: React.FC = () => {
                   amount: 0.7,
                   once: true
                 }}
-                className="sm:w-1/2 grid sm:grid-cols-1 md:grid-cols-2 grid-rows-4 gap-8 collapse sm:visible overflow-hidden"
+                className="md:w-1/2 flex md:grid sm:grid-cols-1 md:grid-cols-2 grid-rows-4 gap-8 mt-8 md:mt-0 overflow-hidden"
             >
-                <motion.div variants={item} className="col-start-2 row-start-1 row-end-3">
-                    <Image className='rounded-xl' width={282} height={408} src='https://picsum.photos/id/49/282/408' alt="" />
+                <motion.div variants={item} className="col-start-2 row-start-1 row-end-3 ">
+                    <Image className='rounded-xl' aria-label='Related Image' width={423} height={600} src='https://picsum.photos/id/49/282/408' alt="Image about me" />
                 </motion.div>
-                <motion.div variants={item} className="row-start-2 row-end-4 collapse md:visible">
-                    <Image className='rounded-xl' width={282} height={408} src='https://picsum.photos/id/59/282/408' alt="" />
+                <motion.div variants={item} className="row-start-2 row-end-4 ">
+                    <Image className='rounded-xl' aria-label='Related Image' width={423} height={600} src='https://picsum.photos/id/59/282/408' alt="Image about me" />
                 </motion.div>
                 <motion.div variants={item} className="col-start-2 row-start-3 row-end-5">
-                    <Image className='rounded-xl' width={282} height={408} src='https://picsum.photos/id/69/282/408' alt="" />
+                    <Image className='rounded-xl' aria-label='Related Image'  width={423} height={600} src='https://picsum.photos/id/69/282/408' alt="Image about me" />
                 </motion.div>
             </motion.div>
         </section>


### PR DESCRIPTION
This commit contains:

- [x] Center items on mobile for the section about
- [X] Show images on mobile in section about
- [X] Remove padding in mobile for less space between the footer and the works


![about me - update](https://github.com/ojedacristian/next-tailwind-portfolio/assets/85720891/681d71a5-b7bd-4b77-b38f-b7bf8e741b73)
